### PR TITLE
Enable word wrap for display of long phenotype values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .classpath
 .project
 .settings/
+.idea
 target/
 bin/

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/styles.css
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/styles.css
@@ -478,6 +478,10 @@ body {
     border-bottom: 1px solid rgb(223, 238, 255);
 }
 
+.search-value {
+    word-break: break-all;
+}
+
 .filter-list-entry {
     margin-left: 0;
     margin-right: 0;


### PR DESCRIPTION
Added CSS for "word-break: break-all" on ".search-value"