### PR TITLE
ALS-1464: Add router override to override the default route

### DIFF
--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/common/router.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/common/router.js
@@ -22,12 +22,10 @@ define(["backbone", "common/session", "login/login", 'header/header', 'footer/fo
             "psamaui/privilegeManagement(/)" : "displayPrivilegeManagement",
             "psamaui/applicationManagement(/)" : "displayApplicationManagement",
             "psamaui/accessRuleManagement(/)" : "displayAccessRuleManagement",
-            "picsureui/queryBuilder" : "displayQueryBuilder",
-            "picsureui/" : "displayQueryBuilder",
+            "picsureui/queryBuilder(/)" : "displayQueryBuilder",
             "picsureui/not_authorized(/)" : "not_authorized",
-
             // This path must be last in the list
-            "*path" : "displayQueryBuilder"
+            "*path" : "defaultAction"
         },
         initialize: function(){
             for (const routeOverride in routerOverrides.routes) {
@@ -201,6 +199,14 @@ define(["backbone", "common/session", "login/login", 'header/header', 'footer/fo
                 }.bind(filterView));
             }
             filterList.init(parsedSettings.picSureResourceId, outputPanelView, renderHelpCallback);
+        },
+        defaultAction: function() {
+            console.log("Default action");
+            if (routerOverrides.defaultAction)
+                routerOverrides.defaultAction();
+            else {
+                this.displayQueryBuilder();
+            }
         }
 
 

--- a/pic-sure-hpds-ui/src/main/webapp/picsureui/overrides/router.js
+++ b/pic-sure-hpds-ui/src/main/webapp/picsureui/overrides/router.js
@@ -8,6 +8,11 @@ define([], function(){
              * Ex:
              * "picsureui/queryBuilder2" : function() { renderQueryBuilder2(); }
              */
-        }
+        },
+        /**
+         * Allows the default action to be overriden. If this is not set, the query builder will be shown for any
+         * route that does not have a defined action
+         */
+        defaultAction: undefined
     };
 });


### PR DESCRIPTION
The specific reason for doing this is that adding another "*path" in the routes overrides does not work as expected.