### PR TITLE
[ALS_4496] Add Swagger to Gitbook

### DIFF
--- a/pic-sure-hpds-ui/httpd/httpd-vhosts.conf
+++ b/pic-sure-hpds-ui/httpd/httpd-vhosts.conf
@@ -44,10 +44,16 @@ Mutex  "file:${HTTPD_PREFIX}/logs/ssl_mutex"
     SSLCertificateKeyFile "${HTTPD_PREFIX}/cert/server.key"
     SSLCertificateChainFile "${HTTPD_PREFIX}/cert/server.chain"
 
-    # Set the Content-Security-Policy header to disallow iframes
     Header always set Content-Security-Policy "frame-ancestors 'none';"
-    # Set the X-Frame-Options header to disallow iframes. This is a fallback for browsers that don't support CSP.
     Header always set X-Frame-Options "DENY"
+
+    <Location ~ "/picsure/(swagger|swagger|openapi|openapi).(json|yaml)">
+        Header always set Access-Control-Allow-Origin "*"
+        Header always set Access-Control-Allow-Methods "GET"
+        Header always set Access-Control-Allow-Headers "Content-Type"
+        Header always set Access-Control-Allow-Credentials "false"
+        Header always set Access-Control-Max-Age "3600"
+    </Location>
 
     RewriteEngine On
     ProxyPreserveHost On


### PR DESCRIPTION
Adding rules to httpd-vhosts.conf to allow swagger to be loaded from a different host. This allows gitbook and swagger ui to load our OpenAPI documentation.